### PR TITLE
 Download music in MP4 format 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use rspotify::model::PlaylistId;
 use rspotify::prelude::BaseClient;
@@ -122,8 +123,8 @@ impl SpotifyHelpers for AuthCodeSpotify {
         tracks.par_iter().for_each(|music|{ 
             let options = SearchOptions::youtube(music);
             let audio = YoutubeDl::search_for(&options)
-                .extract_audio(true)
-                .output_template(music)
+                .output_template(&format!("{}.m4a",music))
+                .format("140")
                 .download_to(output_dir);
             match audio {
                 Ok(_) => println!("{} Download Successfull", music),

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,8 +116,6 @@ async fn main() {
                     &results.tracks,
                     &config.output_dir,
                 );
-                println!("vec downlaoded size  was , {}",results.tracks.len());
-                println!("vec api size  was , {}",results.total.unwrap());
                 results.tracks.len() < usize::try_from(results.total.unwrap()).unwrap()
             } {}
         }


### PR DESCRIPTION
1.  Changed the music format from  .opus to  .m4a 
2. Removed unwanted logs